### PR TITLE
Decode timestamps even as strings.

### DIFF
--- a/graylogd.go
+++ b/graylogd.go
@@ -19,7 +19,7 @@ type GelfLog struct {
 	Host      string  `json:"host"`
 	ShortMsg  string  `json:"short_message"`
 	FullMsg   string  `json:"full_message"`
-	Timestamp float64 `json:"timestamp"`
+	Timestamp float64 `json:"timestamp,string"`
 	Level     int     `json:"level"`
 	Facility  string  `json:"facility"`
 	Line      int     `json:"line"`


### PR DESCRIPTION
The timestamp wouldn't decode properly when a string is passed instead of a JSON number.